### PR TITLE
Enumerable: add a 'depth' option to Enumerable methods. 

### DIFF
--- a/.yardoc-template/default/fulldoc/html/css/0x1eef.css
+++ b/.yardoc-template/default/fulldoc/html/css/0x1eef.css
@@ -1,4 +1,4 @@
-#main #content #filecontents p, .discussion p {
+#main #content #filecontents p, .discussion p, ul.param li {
   max-width: 768px;
 }
 

--- a/README.md
+++ b/README.md
@@ -77,15 +77,18 @@ config.print.call("option (from 'default')", config.option)
 
 #### Ryo.each
 
-The following example demonstrates [`Ryo.each`](https://0x1eef.github.io/x/ryo.rb/Ryo.html#each-class_method) - a method that can iterate through the properties of a Ryo object. Ryo makes every effort
-to not mix its implementation with the objects it creates,
-and that is why [`Ryo.each`](https://0x1eef.github.io/x/ryo.rb/Ryo.html#each-class_method) 
+The following example demonstrates
+[`Ryo.each`](https://0x1eef.github.io/x/ryo.rb/Ryo.html#each-class_method) -
+a method that can iterate through the properties of a Ryo object, and
+its prototype(s). Ryo makes every effort to not mix its implementation
+with the objects it creates -  that's why [`Ryo.each`](https://0x1eef.github.io/x/ryo.rb/Ryo.html#each-class_method)
 is not implemented directly on a Ryo object.
 
-When a block is not given, [`Ryo.each`](https://0x1eef.github.io/x/ryo.rb/Ryo.html#each-class_method)
-returns an Enumerator that provides access to the methods of Enumerable. Methods on Enumerable won't
-return a Ryo object, but often arrays.  Ryo addresses that with its own specialized Enumerable methods
-that are covered below. 
+When a block is not given,
+[`Ryo.each`](https://0x1eef.github.io/x/ryo.rb/Ryo.html#each-class_method)
+returns an Enumerator that provides access to the methods of Ruby's Enumerable.
+Methods on Enumerable won't return a Ryo object, but often arrays. Ryo addresses
+that with [`Ryo::Enumerable`](https://0x1eef.github.io/x/ryo.rb/Ryo/Enumerable.html).
 
 A demonstration of [`Ryo.each`](https://0x1eef.github.io/x/ryo.rb/Ryo.html#each-class_method):
 
@@ -102,18 +105,18 @@ end
 # ["y", 20]
 ```
 
-#### Ryo.map
+#### Ryo.map!
 
-A number of [`Ryo::Enumerable`](http://0x1eef.github.io/x/ryo.rb/Ryo/Enumerable.html) methods 
-can return a new copy of a Ryo object and its prototypes, or mutate a Ryo object and its prototypes 
-in-place. 
-
-The following example demonstrates an in-place map operation on a Ryo object with
+A number of [`Ryo::Enumerable`](http://0x1eef.github.io/x/ryo.rb/Ryo/Enumerable.html) methods
+can return a new copy of a Ryo object and its prototypes, or mutate a Ryo object and its prototypes
+in-place. The following example demonstrates an in-place map operation on a Ryo object with
 [`Ryo.map!`](http://0x1eef.github.io/x/ryo.rb/Ryo/Enumerable.html#map!-instance_method).
 The counterpart of
 [`Ryo.map!`](http://0x1eef.github.io/x/ryo.rb/Ryo/Enumerable.html#map!-instance_method) is
 [`Ryo.map`](http://0x1eef.github.io/x/ryo.rb/Ryo/Enumerable.html#map-instance_method), and
 it returns a new copy of a Ryo object and its prototypes.
+
+A demonstration of [`Ryo.map!`](http://0x1eef.github.io/x/ryo.rb/Ryo/Enumerable.html#map!-instance_method):
 
 ```ruby
 require "ryo"
@@ -136,10 +139,11 @@ p [point_x.x, point_y.y]
 [`Ryo::Enumerable`](http://0x1eef.github.io/x/ryo.rb/Ryo/Enumerable.html) methods
 support an optional `depth` argument.
 
-The `depth` argument can be used to control how far down the prototype chain an
-Enumerable method should go. A depth of 0 covers a Ryo object, and none of its
-prototypes. A depth of 1 covers a Ryo object, and one prototype - and so on.
-By default the entire prototype chain is traversed.
+The `depth` argument can be used to control how far down the prototype chain a
+[`Ryo::Enumerable`](https://0x1eef.github.io/x/ryo.rb/Ryo/Enumerable.html) method
+should go. A depth of 0 covers a Ryo object, and none of its prototypes. A depth
+of 1 covers a Ryo object, and one prototype - and so on. By default the entire
+prototype chain is iterated through.
 
 The following example uses
 [`Ryo.find`](https://0x1eef.github.io/x/ryo.rb/Ryo.html#find-class_method)
@@ -212,13 +216,13 @@ p coords[2].point_y.y.int
 # 4
 ```
 
-#### Ryo.from with Struct / OpenStruct
+#### Ryo.from with OpenStruct
 
 All methods that can create Ryo objects support transforming a Struct, or OpenStruct object
 into a Ryo object. The following example demonstrates how
 [`Ryo.from`](https://0x1eef.github.io/x/ryo.rb/Ryo.html#from-class_method)
 can recursively transform an OpenStruct object into Ryo objects. The example also assigns
-a prototype to the Ryo object created from the OpenStruct object:
+a prototype to the Ryo object created from the OpenStruct:
 
 ``` ruby
 require "ryo"
@@ -302,9 +306,9 @@ p ryo.then { 34 } # => 34
 #### Duck typing
 
 To keep the documentation simple, the objects Ryo works with have been
-described as Hash objects, and Array objects. Technically Ryo makes use of 
-duck typing. When a Hash is mentioned that means *any* object that implements 
-`#each_pair` - while when an Array is mentioned that means *any* object that 
+described as Hash objects, and Array objects. Technically Ryo makes use of
+duck typing. When a Hash is mentioned that means *any* object that implements
+`#each_pair` - while when an Array is mentioned that means *any* object that
 implements `#each`. The only methods that support Array / `#each` objects are
 [Ryo.from](https://0x1eef.github.io/x/ryo.rb/Ryo.html#from-class_method),
 [Ryo::Object.from](https://0x1eef.github.io/x/ryo.rb/Ryo/Object.html#from-class_method)

--- a/README.md
+++ b/README.md
@@ -77,16 +77,17 @@ config.print.call("option (from 'default')", config.option)
 
 #### Ryo.each
 
-The following example demonstrates [`Ryo.each`](https://0x1eef.github.io/x/ryo.rb/Ryo.html#each-class_method) - a method that can iterate through the properties of a Ryo object. Since Ryo takes every effort
+The following example demonstrates [`Ryo.each`](https://0x1eef.github.io/x/ryo.rb/Ryo.html#each-class_method) - a method that can iterate through the properties of a Ryo object. Ryo makes every effort
 to not mix its implementation with the objects it creates,
-[`Ryo.each`](https://0x1eef.github.io/x/ryo.rb/Ryo.html#each-class_method) is not implemented directly
-on a Ryo object.
+and that is why [`Ryo.each`](https://0x1eef.github.io/x/ryo.rb/Ryo.html#each-class_method) 
+is not implemented directly on a Ryo object.
 
 When a block is not given, [`Ryo.each`](https://0x1eef.github.io/x/ryo.rb/Ryo.html#each-class_method)
 returns an Enumerator that provides access to the methods of Enumerable. Methods on Enumerable won't
 return a Ryo object, but often arrays.  Ryo addresses that with its own specialized Enumerable methods
-that are covered just below. For now - a demonstration of
-[`Ryo.each`](https://0x1eef.github.io/x/ryo.rb/Ryo.html#each-class_method):
+that are covered below. 
+
+A demonstration of [`Ryo.each`](https://0x1eef.github.io/x/ryo.rb/Ryo.html#each-class_method):
 
 ```ruby
 require "ryo"
@@ -103,13 +104,13 @@ end
 
 #### Ryo.map
 
-[`Ryo::Enumerable`](http://0x1eef.github.io/x/ryo.rb/Ryo/Enumerable.html) provides
-specialized implementations of Enumerable methods that can return a new copy of a Ryo
-object and its prototypes, or mutate a Ryo object and its prototypes in-place.
+A number of [`Ryo::Enumerable`](http://0x1eef.github.io/x/ryo.rb/Ryo/Enumerable.html) methods 
+can return a new copy of a Ryo object and its prototypes, or mutate a Ryo object and its prototypes 
+in-place. 
 
-The following example demonstrates a mutating map operation of a Ryo object with
+The following example demonstrates an in-place map operation on a Ryo object with
 [`Ryo.map!`](http://0x1eef.github.io/x/ryo.rb/Ryo/Enumerable.html#map!-instance_method).
-The non-mutating counterpart of
+The counterpart of
 [`Ryo.map!`](http://0x1eef.github.io/x/ryo.rb/Ryo/Enumerable.html#map!-instance_method) is
 [`Ryo.map`](http://0x1eef.github.io/x/ryo.rb/Ryo/Enumerable.html#map-instance_method), and
 it returns a new copy of a Ryo object and its prototypes.
@@ -128,6 +129,33 @@ p [point_x.x, point_y.y]
 ##
 # [4, 8]
 # [4, 8]
+```
+
+#### Depth
+
+[`Ryo::Enumerable`](http://0x1eef.github.io/x/ryo.rb/Ryo/Enumerable.html) methods
+support an optional `depth` argument.
+
+The `depth` argument can be used to control how far down the prototype chain an
+Enumerable method should go. A depth of 0 covers a Ryo object, and none of its
+prototypes. A depth of 1 covers a Ryo object, and one prototype - and so on.
+By default the entire prototype chain is traversed.
+
+The following example uses
+[`Ryo.find`](https://0x1eef.github.io/x/ryo.rb/Ryo.html#find-class_method)
+to demonstrate how that works in practice:
+
+```ruby
+require "ryo"
+
+point_a = Ryo(x: 5)
+point_b = Ryo({y: 10}, point_a)
+point_c = Ryo({z: 15}, point_b)
+
+p Ryo.find(point_c, depth: 0) { |k,v| v == 5 } # => nil
+p Ryo.find(point_c, depth: 1) { |k,v| v == 5 } # => nil
+p Ryo.find(point_c, depth: 2) { |k,v| v == 5 } # => point_a
+p Ryo.find(point_c){ |k,v| v == 5 } # => point_a
 ```
 
 ### Recursion

--- a/readme_examples/2.2_iteration_depth.rb
+++ b/readme_examples/2.2_iteration_depth.rb
@@ -1,0 +1,11 @@
+require_relative "setup"
+require "ryo"
+
+point_a = Ryo(x: 5)
+point_b = Ryo({y: 10}, point_a)
+point_c = Ryo({z: 15}, point_b)
+
+p Ryo.find(point_c, depth: 0) { |k,v| v == 5 } # => nil
+p Ryo.find(point_c, depth: 1) { |k,v| v == 5 } # => nil
+p Ryo.find(point_c, depth: 2) { |k,v| v == 5 } # => point_a
+p Ryo.find(point_c){ |k,v| v == 5 } # => point_a

--- a/spec/ryo_enumerable_spec.rb
+++ b/spec/ryo_enumerable_spec.rb
@@ -108,22 +108,90 @@ RSpec.describe Ryo::Enumerable do
 
     context "when an iteration yields true on point_a" do
       subject { Ryo.find(point_c) { _2 == 5 } }
-      it { is_expected.to eq(point_a) }
+      it { is_expected.to be(point_a) }
     end
 
     context "when an iteration yields true on point_b" do
       subject { Ryo.find(point_c) { _2 == 10 } }
-      it { is_expected.to eq(point_b) }
+      it { is_expected.to be(point_b) }
     end
 
     context "when an iteration yields true on point_c" do
       subject { Ryo.find(point_c) { _2 == 15 } }
-      it { is_expected.to eq(point_c) }
+      it { is_expected.to be(point_c) }
     end
 
     context "when an iteration never yields true" do
       subject { Ryo.find(point_c) { _2 == 20 } }
       it { is_expected.to eq(nil) }
+    end
+
+    context "with a depth of zero" do
+      context "when the condition matches for point_a" do
+        subject { Ryo.find(point_c, depth: 0) { _2 == 5 } }
+        it { is_expected.to be_nil}
+      end
+
+      context "when the condition matches for point_b" do
+        subject { Ryo.find(point_c, depth: 0) { _2 == 10 } }
+        it { is_expected.to be_nil }
+      end
+
+      context "when the condition matches for point_c" do
+        subject { Ryo.find(point_c, depth: 0) { _2 == 15 } }
+        it { is_expected.to be(point_c) }
+      end
+    end
+
+    context "with a depth of one" do
+      context "when the condition matches for point_a" do
+        subject { Ryo.find(point_c, depth: 1) { _2 == 5 } }
+        it { is_expected.to be_nil}
+      end
+
+      context "when the condition matches for point_b" do
+        subject { Ryo.find(point_c, depth: 1) { _2 == 10 } }
+        it { is_expected.to be(point_b) }
+      end
+
+      context "when the condition matches for point_c" do
+        subject { Ryo.find(point_c, depth: 1) { _2 == 15 } }
+        it { is_expected.to be(point_c) }
+      end
+    end
+
+    context "with a depth of two" do
+      context "when the condition matches for point_a" do
+        subject { Ryo.find(point_c, depth: 2) { _2 == 5 } }
+        it { is_expected.to be(point_a) }
+      end
+
+      context "when the condition matches for point_b" do
+        subject { Ryo.find(point_c, depth: 2) { _2 == 10 } }
+        it { is_expected.to be(point_b) }
+      end
+
+      context "when the condition matches for point_c" do
+        subject { Ryo.find(point_c, depth: 2) { _2 == 15 } }
+        it { is_expected.to be(point_c) }
+      end
+    end
+
+    context "with a depth of three (or higher)" do
+      context "when the condition matches for point_a" do
+        subject { Ryo.find(point_c, depth: 3) { _2 == 5 } }
+        it { is_expected.to be(point_a) }
+      end
+
+      context "when the condition matches for point_b" do
+        subject { Ryo.find(point_c, depth: 3) { _2 == 10 } }
+        it { is_expected.to be(point_b) }
+      end
+
+      context "when the condition matches for point_c" do
+        subject { Ryo.find(point_c, depth: 3) { _2 == 15 } }
+        it { is_expected.to be(point_c) }
+      end
     end
   end
 end

--- a/spec/ryo_enumerable_spec.rb
+++ b/spec/ryo_enumerable_spec.rb
@@ -5,48 +5,48 @@ require_relative "setup"
 RSpec.describe Ryo::Enumerable do
   describe ".each" do
     context "when verifying each traverses through the prototype chain" do
-      subject { Ryo.each(point).map { [_1, _2] } }
-      let(:point_x) { Ryo(x: 0) }
-      let(:point_y) { Ryo({y: 5}, point_x) }
-      let(:point) { Ryo({}, point_y) }
+      subject { Ryo.each(point_c).map { [_1, _2] } }
+      let(:point_a) { Ryo(x: 0) }
+      let(:point_b) { Ryo({y: 5}, point_a) }
+      let(:point_c) { Ryo({}, point_b) }
       it { is_expected.to eq([["y", 5], ["x", 0]]) }
     end
   end
 
   describe ".map" do
-    let(:base) { Ryo::BasicObject(x: 4, y: 4) }
-    let(:point) { Ryo::BasicObject({x: 2, y: 2}, base) }
-    subject(:mpoint) { Ryo.map(point) { _2 * 2 } }
+    let(:point_a) { Ryo::BasicObject(x: 4, y: 4) }
+    let(:point_b) { Ryo::BasicObject({x: 2, y: 2}, point_a) }
+    subject(:point_c) { Ryo.map(point_b) { _2 * 2 } }
 
     context "when verifying the map operation" do
       it { is_expected.to eq({x: 4, y: 4}) }
     end
 
     context "when verifying the map operation on the prototype" do
-      subject { base }
-      before { Ryo.map!(point) { _2 * 2 } }
+      subject { point_a }
+      before { Ryo.map!(point_b) { _2 * 2 } }
       it { is_expected.to eq({x: 8, y: 8}) }
     end
 
     context "when verifying the map operation returns a new object" do
-      subject { Ryo.kernel(:equal?).bind_call(point, mpoint) }
+      subject { Ryo.kernel(:equal?).bind_call(point_b, point_c) }
       it { is_expected.to be(false) }
     end
   end
 
   describe ".select" do
     context "with prototype chain traversal" do
-      subject { Ryo.select(point) { _1 == "y" and _2 == 4 } }
-      let(:base) { Ryo::BasicObject(x: 1, y: 2) }
-      let(:point) { Ryo::BasicObject({x: 3, y: 4}, base) }
+      subject { Ryo.select(point_b) { _1 == "y" and _2 == 4 } }
+      let(:point_a) { Ryo::BasicObject(x: 1, y: 2) }
+      let(:point_b) { Ryo::BasicObject({x: 3, y: 4}, point_a) }
 
       context "when verifying the filter operation" do
         it { is_expected.to eq(y: 4) }
       end
 
       context "when verifying the filter operation on the prototype" do
-        subject { base.y }
-        before { Ryo.select!(point) { _1 == "x" } }
+        subject { point_a.y }
+        before { Ryo.select!(point_b) { _1 == "x" } }
         it { is_expected.to eq(nil) }
       end
     end
@@ -54,33 +54,33 @@ RSpec.describe Ryo::Enumerable do
 
   describe ".reject" do
     context "with prototype chain traversal" do
-      subject { Ryo.reject(point) { _1 == "x" } }
-      let(:base) { Ryo::BasicObject(x: 1, y: 2) }
-      let(:point) { Ryo::BasicObject({x: 3, y: 4}, base) }
+      subject { Ryo.reject(point_b) { _1 == "x" } }
+      let(:point_a) { Ryo::BasicObject(x: 1, y: 2) }
+      let(:point_b) { Ryo::BasicObject({x: 3, y: 4}, point_a) }
 
       context "when verifying the filter operation" do
         it { is_expected.to eq(y: 4) }
       end
 
       context "when verifying the filter operation on the prototype" do
-        subject { base.y }
-        before { Ryo.reject!(point) { _1 == "y" } }
+        subject { point_a.y }
+        before { Ryo.reject!(point_b) { _1 == "y" } }
         it { is_expected.to eq(nil) }
       end
     end
   end
 
   describe ".any?" do
-    let(:base) { Ryo::BasicObject(y: 10) }
-    let(:point) { Ryo::BasicObject({x: 5}, base) }
+    let(:point_a) { Ryo::BasicObject(y: 10) }
+    let(:point_b) { Ryo::BasicObject({x: 5}, point_a) }
 
     context "when an iteration returns a truthy value" do
-      subject { Ryo.any?(point) { _2 > 5} }
+      subject { Ryo.any?(point_b) { _2 > 5} }
       it { is_expected.to be(true) }
     end
 
     context "when an iteration fails to return a truthy value" do
-      subject { Ryo.any?(point) { _2 > 20 } }
+      subject { Ryo.any?(point_b) { _2 > 20 } }
       it { is_expected.to be(false) }
     end
   end


### PR DESCRIPTION
The 'depth' option can be used to limit how far through the
prototype chain a method can go. A depth of 0 covers a Ryo object,
and none of its prototypes. A depth of 1 covers a Ryo object, and
one prototype - and so on.

Checklist
- [x] Add depth option
- [x] Refactor docs