### PR TITLE
Add Ryo object support to `.from`, and `.create`.

### DIFF
--- a/spec/readme_spec.rb
+++ b/spec/readme_spec.rb
@@ -74,6 +74,6 @@ RSpec.describe "README.md examples" do
 
   context "when given 7_ryo_lazy.rb" do
     let(:file) { "7_ryo_lazy.rb" }
-    it { is_expected.to eq("point.x = 5\npoint.y = 10\npoint.sum = 15")}
+    it { is_expected.to eq("point.x = 5\npoint.y = 10\npoint.sum = 15") }
   end
 end

--- a/spec/ryo_basic_object_spec.rb
+++ b/spec/ryo_basic_object_spec.rb
@@ -24,6 +24,12 @@ RSpec.describe Ryo::BasicObject do
   end
 
   describe ".from" do
+    context "when given an instance of Ryo::BasicObject" do
+      subject { Ryo.from(point) }
+      let(:point) { Ryo::BasicObject(x: 5, y: 10) }
+      it { is_expected.to eq(point) }
+    end
+
     context "when given nested Hash objects" do
       subject { point.x.to_i }
       let(:point) { Ryo::BasicObject.from({x: {to_i: 4}}) }

--- a/spec/ryo_spec.rb
+++ b/spec/ryo_spec.rb
@@ -4,6 +4,12 @@ require_relative "setup"
 
 RSpec.describe Ryo do
   describe ".from" do
+    context "when given an instance of Ryo::Object" do
+      subject { Ryo.from(point) }
+      let(:point) { Ryo(x: 5, y: 10) }
+      it { is_expected.to eq(point) }
+    end
+
     context "when given { key => Hash<Symbol, Integer> }" do
       subject { point.x.to_i }
       let(:point) { Ryo.from({x: {to_i: 4}}) }


### PR DESCRIPTION
When `Ryo.from`, `Ryo::Object.{from,create}`, or
`Ryo::BasicObject.{create,from}` are given a
 Ryo object, a duplicate Ryo object is returned
 in their place. Beforehand, an empty Ryo object
was returned.