### PR TITLE
Add `recursive` option to `Ryo.table_of`.

### DIFF
--- a/lib/ryo/reflect.rb
+++ b/lib/ryo/reflect.rb
@@ -168,15 +168,25 @@ module Ryo::Reflect
   end
 
   ##
-  #
   # @param [<Ryo::Object, Ryo::BasicObject>] ryo
   #  A Ryo object.
   #
+  # @param [Boolean] recursive
+  #  When true, nested Ryo objects are replaced by
+  #  their table as well.
+  #
   # @return [Hash]
   #  Returns the table of a Ryo object.
-  def table_of(ryo)
-    kernel(:instance_variable_get)
-      .bind_call(ryo, :@_table)
+  def table_of(ryo, recursive: false)
+    table = kernel(:instance_variable_get).bind_call(ryo, :@_table)
+    if recursive
+      table.each do |key, value|
+        if ryo?(value)
+          table[key] = table_of(value)
+        end
+      end
+    end
+    table
   end
 
   ##

--- a/spec/ryo_reflect_spec.rb
+++ b/spec/ryo_reflect_spec.rb
@@ -141,4 +141,27 @@ RSpec.describe Ryo::Reflect do
       it { is_expected.to be(point_a) }
     end
   end
+
+  describe ".table_of" do
+    subject(:table) { Ryo.table_of(ryo, recursive:) }
+
+    context "without recursion" do
+      let(:recursive) { false }
+      context "when given a Ryo object" do
+        let(:ryo) { Ryo(x: 1, y:1) }
+        it { is_expected.to be_instance_of(Hash) }
+        it { is_expected.to eq("x" => 1, "y" => 1) }
+      end
+    end
+
+    context "with recursion" do
+      let(:recursive) { true }
+      context "when a Ryo object nests another Ryo object" do
+        let(:ryo) { Ryo(point: Ryo(x: 1, y: 1)) }
+        it { expect(table).to be_instance_of(Hash) }
+        it { expect(table["point"]).to be_instance_of(Hash) }
+        it { is_expected.to eq("point" => {"x" => 1, "y" => 1}) }
+      end
+    end
+  end
 end


### PR DESCRIPTION
Defaults to false.
When true, nested Ryo objects are replaced by their table as well.